### PR TITLE
ORCA-105/nf validate dag

### DIFF
--- a/dags/nf-hello-test.py
+++ b/dags/nf-hello-test.py
@@ -1,0 +1,54 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+
+from sagetasks.nextflowtower.utils import TowerUtils
+
+
+@dag(
+    schedule_interval=None,
+    start_date=datetime(2022, 11, 11),
+    catchup=False,
+    default_args={
+        "retries": 2,
+    },
+    tags=["nextflow_tower"],
+)
+def nf_hello_test_dag():
+    @task(multiple_outputs=True)
+    def open_tower_workspace():
+        """
+        Opens tower workspace - things are hard coded for the moment that would be parameterized in future versions
+
+        Returns:
+            dict: TowerUtils class instance within dictionary for easy variable passing
+        """
+        tower_token = os.environ["TOWER_ACCESS_TOKEN"]
+        client_args = TowerUtils.bundle_client_args(
+            tower_token, platform="sage-dev", debug_mode=False
+        )
+        tower_utils = TowerUtils(client_args)
+        return {"tower_utils": tower_utils}
+
+    @task()
+    def launch_tower_workflow(tower_utils: TowerUtils, workspace_id: str):
+        """
+        Launches tower workflow
+
+        Args:
+            tower_utils (sagetasks.nextflowtower.utils.TowerUtils): TowerUtils class instance
+            workspace_id (str): Workspace ID for tower run
+        """
+        tower_utils.open_workspace(workspace_id)
+        tower_utils.launch_workflow(
+            compute_env_id="635ROvIWp5w17QVdRy0jkk",
+            pipeline="nextflow-io/hello",
+            run_name="nf-hello-test",
+        )
+
+    tower_utils = open_tower_workspace()
+    launch_tower_workflow(tower_utils["tower_utils"], "4034472240746")
+
+
+nf_hello_test_dag = nf_hello_test_dag()

--- a/dags/nf-validate.py
+++ b/dags/nf-validate.py
@@ -24,7 +24,7 @@ def nf_validate_dag():
         Returns:
             dict: TowerUtils class instance within dictionary for easy variable passing
         """
-        tower_token = os.environ["TOWER_ACCESS_TOKEN"]
+        tower_token = os.environ["TOWER_ACCESS_TOKEN"] # TODO configure secrets instead of using env variables
         client_args = TowerUtils.bundle_client_args(
             tower_token, platform="sage", debug_mode=False
         )
@@ -44,10 +44,9 @@ def nf_validate_dag():
         tower_utils.launch_workflow(
             compute_env_id="1QX5bol8rZHBZkTAEIvQts",
             pipeline="Sage-Bionetworks-Workflows/nf-validate",
-            revision="bb81bf2",
-            run_name="nf-validate-demo",
+            revision="main",
             profiles=["docker"],
-            user_secrets=["SYNAPSE_AUTH_TOKEN"],
+            user_secrets=["SYNAPSE_AUTH_TOKEN"], # TODO need to get a workspace secret in the HTAN tower workspace that has more access - don't have permission to create one
         )
 
     tower_utils = open_tower_workspace()

--- a/dags/nf-validate.py
+++ b/dags/nf-validate.py
@@ -15,7 +15,7 @@ from sagetasks.nextflowtower.utils import TowerUtils
     },
     tags=["nextflow_tower"],
 )
-def nf_hello_dag():
+def nf_validate_dag():
     @task(multiple_outputs=True)
     def open_tower_workspace():
         """
@@ -43,12 +43,15 @@ def nf_hello_dag():
         tower_utils.open_workspace(workspace_id)
         tower_utils.launch_workflow(
             compute_env_id="1QX5bol8rZHBZkTAEIvQts",
-            pipeline="nextflow-io/hello",
-            run_name="nf-hello_test",
+            pipeline="Sage-Bionetworks-Workflows/nf-validate",
+            revision="bb81bf2",
+            run_name="nf-validate-demo",
+            profiles=["docker"],
+            user_secrets=["SYNAPSE_AUTH_TOKEN"],
         )
 
     tower_utils = open_tower_workspace()
     launch_tower_workflow(tower_utils["tower_utils"], "253119656982040")
 
 
-nf_hello_dag = nf_hello_dag()
+nf_validate_dag = nf_validate_dag()


### PR DESCRIPTION
This PR adds the nf-validate dag. It is basic and somewhat hard-coded for this current version. It follows the same basic pattern as the nf-hello dag, and will be further developed in the future to allow more parameters and configuration by users. It has been tested both locally and in the ec2 instance.